### PR TITLE
[Feature] Added routes for posting and getting users rosters + tests

### DIFF
--- a/server/db/models/UserLeague.js
+++ b/server/db/models/UserLeague.js
@@ -2,9 +2,9 @@ var Sequelize = require("sequelize");
 
 module.exports = function(sequelize, tableConfig) {
 	return sequelize.define('user_league', {
-    current_score: {
-        type: Sequelize.INTEGER, 
-        defaultValue: 0
-      }
+	    current_score: {
+	        type: Sequelize.INTEGER, 
+	        defaultValue: 0
+	      }
 	}, tableConfig); 
 }

--- a/server/db/models/UserRoster.js
+++ b/server/db/models/UserRoster.js
@@ -2,6 +2,9 @@ var Sequelize = require("sequelize");
 
 module.exports = function(sequelize, tableConfig) {
 	return sequelize.define('user_roster', {
-
+		current_score: {
+			type: Sequelize.INTEGER,
+			defaultValue: 0
+		}
 	}, tableConfig);
 }

--- a/server/dbConfig.js
+++ b/server/dbConfig.js
@@ -55,6 +55,15 @@ var createSchemas = function(dbConnection, construct) {
 	LeagueEvent.belongsTo(League);
 	League.hasMany(LeagueEvent, {onDelete: 'cascade'});
 
+	//associations for the user roster table
+	UserRoster.belongsTo(League);
+	UserRoster.belongsTo(LeagueCharacter);
+	UserRoster.belongsTo(LeagueEvent);
+	League.hasMany(UserRoster);
+	LeagueCharacter.hasMany(UserRoster);
+	LeagueEvent.hasMany(UserRoster);
+
+
 	//associations for the CharacterEvent table
 	CharacterEvent.belongsTo(League);
 	CharacterEvent.belongsTo(LeagueCharacter);

--- a/server/dbConfig.js
+++ b/server/dbConfig.js
@@ -58,10 +58,10 @@ var createSchemas = function(dbConnection, construct) {
 	//associations for the user roster table
 	UserRoster.belongsTo(League);
 	UserRoster.belongsTo(LeagueCharacter);
-	UserRoster.belongsTo(LeagueEvent);
+	UserRoster.belongsTo(User);
 	League.hasMany(UserRoster);
 	LeagueCharacter.hasMany(UserRoster);
-	LeagueEvent.hasMany(UserRoster);
+	User.hasMany(UserRoster);
 
 
 	//associations for the CharacterEvent table

--- a/server/routes.js
+++ b/server/routes.js
@@ -27,6 +27,12 @@ function setup(app, routeHandlers, deleteHandlers) {
     .post(routeHandlers.leagueCharactersPOST);
   app.route('/league/:leagueId/invite')
     .post(routeHandlers.leagueInvitePOST);
+  app.route('league/:leagueId/roster')
+    .all(auth)
+    .post(routeHandlers.rosterPOST);
+  app.route('league/:leagueId/user/:userId/roster')
+    .all(auth)
+    .get(routeHandlers.rosterGET);
   app.route('/user/leagues')
     .get(routeHandlers.userLeaguesGET);
   app.route('/league/:leagueId/triggerevent')

--- a/server/routes.js
+++ b/server/routes.js
@@ -27,10 +27,10 @@ function setup(app, routeHandlers, deleteHandlers) {
     .post(routeHandlers.leagueCharactersPOST);
   app.route('/league/:leagueId/invite')
     .post(routeHandlers.leagueInvitePOST);
-  app.route('league/:leagueId/roster')
+  app.route('/league/:leagueId/roster')
     .all(auth)
     .post(routeHandlers.rosterPOST);
-  app.route('league/:leagueId/user/:userId/roster')
+  app.route('/league/:leagueId/user/:userId/roster')
     .all(auth)
     .get(routeHandlers.rosterGET);
   app.route('/user/leagues')

--- a/server/specs/apiSpecs.js
+++ b/server/specs/apiSpecs.js
@@ -10,10 +10,26 @@ var db = require('../dbConfig');
 
 var utils = {
 	testUser: {
-				username: 'testUser',
-				email: "testemail@gmail.com",
-				password: '123qwe'
+		username: 'testUser',
+		email: "testemail@gmail.com",
+		password: '123qwe'
 	},
+
+	otherTestUser: {
+		username: 'otherTestUser',
+		email: "othertestemail@gmail.com",
+		password: '123qwe'
+	},
+
+	testLeague: {
+		name: "leagueName",
+		show: "tvShow",
+		roster_limit: 10
+	},
+
+	testCharacter: {
+		name: "testCharacterName"
+	},	
 
 	errOrDone: function(err, res, done) {
 		if (err) {
@@ -53,7 +69,8 @@ var utils = {
 						callback(err);
 					}
 					else {
-						callback();
+						//user object can be accessed in callback
+						callback(res.body);
 					}
 				}
 			});
@@ -102,8 +119,10 @@ describe('API', function() {
 
 	//deletes inserted user from database after all tests are complete
 	after(function(done) {
-		utils.destroyUser(User,utils.testUser, done);
-	})
+		utils.destroyUser(User, utils.testUser, function() {
+			utils.destroyUser(User, utils.otherTestUser, done);
+		});
+	});
 
 	describe('user management', function() {
 
@@ -162,7 +181,9 @@ describe('API', function() {
 			var agent = utils.createAgent();
 			before(function(done) {
 				utils.signUpUser(utils.testUser);
-				utils.logInAgent(agent, utils.testUser, done);
+				utils.logInAgent(agent, utils.testUser, function(user) {
+					done();
+				});
 			});
 
 			it('should respond with a 401 if user attempts to access protected route while not logged in', function(done) {
@@ -193,7 +214,9 @@ describe('API', function() {
 
 		before(function(done) {
 			utils.signUpUser(utils.testUser);
-			utils.logInAgent(agent, utils.testUser, done);
+			utils.logInAgent(agent, utils.testUser, function(user) {
+				done();
+			});
 		})
 
 		after(function(done) {
@@ -359,40 +382,115 @@ describe('API', function() {
 
 	describe("League draft / roster", function() {
 		var agent = utils.createAgent();
+		var leagueId;
+		var userId;
+		var characterId;
+		//used to make sure that trying to draft the same character twice doesnt create a new object in the database
+		var firstDraftId;
 
 		before(function(done) {
-			//signup/login user
-
-			//create league
-
-			//create character
-			done();
+			utils.signUpUser(utils.testUser, function() {
+				utils.logInAgent(agent, utils.testUser, function(user) {
+					userId = user.id;
+					agent.post('/league')
+					.send(utils.testLeague)
+					.expect(201)
+					.end(function(err, res) {
+						leagueId = res.body.id;
+						agent.post("/league/" + leagueId + "/characters")
+							.send(utils.testCharacter)
+							.expect(201)
+							.end(function (err, res) {
+								characterId = res.body.id;
+								done();
+							});
+					});
+				});
+			});
 		})
 
 		after(function(done) {
-			done();
-		})
+			League.find({where: {id: leagueId}}).then(function(foundLeague) {
+				foundLeague.destroy().then(function() {
+					done();
+				})
+			})
+		});
 
 		describe("roster POST - draft player", function() {
 			it("should return the drafted player object", function(done) {
-				done();
+				agent.post("/league/" + leagueId + "/roster")
+					.send({
+						userId: userId,
+						characterId: characterId
+					})
+					.expect(201)
+					.expect(function(res) {
+						res.body.id.should.exist;
+						res.body.league_id.should.equal(leagueId);
+						res.body.user_id.should.equal(userId);
+						res.body.league_character_id.should.equal(characterId);
+					})
+					.end(function(err, res) {
+						firstDraftId = res.body.id;
+						utils.errOrDone(err, res, done);
+					})
 			});
 
 			it("should not allow a user to draft the same player twice", function(done) {
-				done();
+				agent.post("/league/" + leagueId + "/roster")
+					.send({
+						userId: userId,
+						characterId: characterId
+					})
+					.expect(200)
+					.expect(function(res) {
+						/*make sure its the same id as the first test - this creates a dependency between
+						tests that doesnt need to be there, but I think its ok for now*/
+						res.body.id.should.equal(firstDraftId);
+						res.body.league_id.should.equal(leagueId);
+						res.body.user_id.should.equal(userId);
+						res.body.league_character_id.should.equal(characterId);
+					})
+					.end(function(err, res) {
+						utils.errOrDone(err, res, done);
+					})
 			})
 		});
 
 		describe("roster GET - get users roster", function() {
-			it("should return the users roster", function(done) {
-				done();
+			it("should return the users roster as an array", function(done) {
+				agent.get("/league/" + leagueId + "/user/" + userId + "/roster")
+					.expect(200)
+					.expect(function(res) {
+						res.body[0].id.should.equal(firstDraftId);
+						res.body[0].league_id.should.equal(leagueId);
+						res.body[0].user_id.should.equal(userId);
+						res.body[0].league_character_id.should.equal(characterId);
+					})
+					.end(function(err, res) {
+						utils.errOrDone(err, res, done);
+					})
 			});
 
+			//not implemented in routehandler yet
 			it("should only allow users to view the rosters of players in the same league as them", function(done) {
-				done();
-			})
+				var otherAgent = utils.createAgent();
+
+				utils.signUpUser(utils.otherTestUser, function() {
+					utils.logInAgent(agent, utils.otherTestUser, function(user) {
+						agent.get("/league/" + leagueId + "/user/" + userId + "/roster")
+							.expect(401)
+							.end(function(err, res) {
+								utils.errOrDone(err, res, done);
+							})
+						});
+					});
+				});
+
+			});
 		});
-	});
+	// });
 
 	describe("league events", function() {
 			var agent = utils.createAgent();

--- a/server/specs/apiSpecs.js
+++ b/server/specs/apiSpecs.js
@@ -361,6 +361,11 @@ describe('API', function() {
 		var agent = utils.createAgent();
 
 		before(function(done) {
+			//signup/login user
+
+			//create league
+
+			//create character
 			done();
 		})
 
@@ -372,6 +377,10 @@ describe('API', function() {
 			it("should return the drafted player object", function(done) {
 				done();
 			});
+
+			it("should not allow a user to draft the same player twice", function(done) {
+				done();
+			})
 		});
 
 		describe("roster GET - get users roster", function() {

--- a/server/specs/apiSpecs.js
+++ b/server/specs/apiSpecs.js
@@ -357,6 +357,34 @@ describe('API', function() {
 		});
 	}); //end of league Characters test
 
+	describe("League draft / roster", function() {
+		var agent = utils.createAgent();
+
+		before(function(done) {
+			done();
+		})
+
+		after(function(done) {
+			done();
+		})
+
+		describe("roster POST - draft player", function() {
+			it("should return the drafted player object", function(done) {
+				done();
+			});
+		});
+
+		describe("roster GET - get users roster", function() {
+			it("should return the users roster", function(done) {
+				done();
+			});
+
+			it("should only allow users to view the rosters of players in the same league as them", function(done) {
+				done();
+			})
+		});
+	});
+
 	describe("league events", function() {
 			var agent = utils.createAgent();
 			var testLeague = {


### PR DESCRIPTION
The api can handle roster additions being posted one at a time and get requests will return an array of a users entire roster. Users can only view the roster of other users that are in the same league as them. There are also associated tests for each of these functions.
