### PR TITLE
[Feature] - League show user rosters and total scores now display properly

### DIFF
--- a/client/app/leagues/show/show.html
+++ b/client/app/leagues/show/show.html
@@ -43,7 +43,7 @@
 </div>
 <div ng-repeat="user in users" class="listView">
   <span class="left" ng-click="showRoster($index, user.id)"><i class="fa fa-caret-right space"></i>  {{user.username}}</span>
-  <span class="points right"> {{user.user_leagues[0].current_score}} pts</span>
+  <span class="points right"> {{returnUserRoster(user.id).totalScore}} pts</span>
   <div class="roster" ng-show="$index == indexSelect">
     roster:
     <div>

--- a/client/app/leagues/show/show.html
+++ b/client/app/leagues/show/show.html
@@ -1,4 +1,5 @@
-<div ng-if="isOwner()">
+<!-- <div ng-if="isOwner()"> -->
+<div>
 <!-- <button class="backToLeagues textLink" ng-click="go('/leagues/list')"><i class="fa fa-arrow-left"></i> Back to Leagues</button> -->
 <div class="clearfix">
   <div  class="leagueInfo left">
@@ -43,15 +44,15 @@
 </div>
 <div ng-repeat="user in users" class="listView">
   <span class="left" ng-click="showRoster($index, user.id)"><i class="fa fa-caret-right space"></i>  {{user.username}}</span>
-  <span class="points right"> {{returnUserRoster(user.id).totalScore}} pts</span>
+  <span class="points right"> {{userRosters[user.id].totalScore}} pts</span>
   <div class="roster" ng-show="$index == indexSelect">
     roster:
     <div>
       <div ng-show="user.roster.length == 0">
         No roster drafted by this user
       </div>
-      <div class="characInRosters" ng-repeat='roster in user.roster'>
-        {{roster.league_character.name}}  {{roster.current_score}}
+      <div class="characInRosters" ng-repeat='roster in userRosters[user.id]'>
+        {{roster.league_character.name}} - {{roster.current_score}} pts
       </div>
     </div>
   </div>

--- a/client/app/leagues/show/showLeagueController.js
+++ b/client/app/leagues/show/showLeagueController.js
@@ -11,6 +11,8 @@ angular.module('app.leagues.show', [])
   $scope.showUserRoster = true;
   $scope.charEventTrigger = {};
 
+  $scope.returnUserRoster = ShowLeague.returnUserRoster;
+
   $scope.setCharacter = function() {
     $scope.charEventTrigger.characterId = this.character.id;
   }
@@ -53,9 +55,7 @@ angular.module('app.leagues.show', [])
   $scope.showRoster = function(index, userId) {
     $scope.indexSelect = index;
 
-    ShowLeague.getUserRoster($scope.league.id, $scope.users[index].id, function (err, response){
-      $scope.users[index].roster = response;
-    });
+    $scope.users[index] = ShowLeague.returnUserRoster($scope.users[index].id);
   }
 
   $scope.getLeague = function (){
@@ -108,6 +108,7 @@ angular.module('app.leagues.show', [])
 .factory('ShowLeague', function ($http, $stateParams) {
 
   var triggeredEvents = [];
+  var userRosters = {};
 
   var getLeague = function(id, callback) {
     $http({
@@ -165,11 +166,24 @@ angular.module('app.leagues.show', [])
       url: '/league/' + leagueId + '/user/' + userId + '/roster',
     })
     .success(function (res) {
+      userRosters[userId] = {
+        roster: res
+      }
+
+      userRosters[userId].totalScore = 0;
+      for (var i = 0; i < userRosters[userId].roster.length; i++) {
+        userRosters[userId].totalScore += userRosters[userId].roster[i].current_score;
+      }
+
       callback(false, res);
     })
     .error(function (err) {
       callback(true, err);
     });
+  };
+
+  var returnUserRoster = function(userId) {
+    return userRosters[userId];
   };
 
   var triggerEvent = function(charEvent, callback) {
@@ -195,6 +209,7 @@ angular.module('app.leagues.show', [])
     getEvents: getEvents,
     getCharacters: getCharacters,
     getUserRoster: getUserRoster,
+    returnUserRoster: returnUserRoster,
     triggerEvent: triggerEvent
   };
 });

--- a/client/app/leagues/show/showLeagueController.js
+++ b/client/app/leagues/show/showLeagueController.js
@@ -53,7 +53,14 @@ angular.module('app.leagues.show', [])
     //$scope.drafted = false;
 
   $scope.showRoster = function(index, userId) {
-    $scope.indexSelect = index;
+    //if that roster is already being displayed, close it
+    if ($scope.indexSelect === index) {
+      $scope.indexSelect = null;
+    }
+    else {
+      //display roster of the user that was clicked
+      $scope.indexSelect = index;
+    }
   }
 
   $scope.getLeague = function (){

--- a/client/app/main.js
+++ b/client/app/main.js
@@ -20,4 +20,8 @@ angular.module('app', [
   };
 
   $scope.checkUser();
+
+  $scope.returnUser = function() {
+    return JSON.parse(localStorage.getItem('user'));
+  }
 });

--- a/client/index.html
+++ b/client/index.html
@@ -11,7 +11,7 @@
 <body ng-app='app' ng-controller='appController'>
     <div class="nav">
       <nav class="logOutNav" ng-controller='userController'>
-        <button ng-show='userState' class="logOut" ng-click="logout()"><i class="fa fa-sign-out"></i></button>
+        <button ng-show='userState' class="logOut" ng-click="logout()">{{returnUser().username}} <i class="fa fa-sign-out"></i></button>
       </nav>
     </div>
   <div class="mainContainer">


### PR DESCRIPTION
League show panel now properly displays rosters, individual character scores, as well as users total scores. Also, the current logged in users name now displays at the top of the page next to the signout button. Finally, clicking a user while their roster is open will cause it to collapse and close.
